### PR TITLE
luci-app-ssr-plus：Fix `Hysteria2` failure to start problem

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -290,7 +290,7 @@ local hysteria = {
 	transport = {
 		type = server.transport_protocol,
 		udp = { 
-			hopInterval = tonumber(server.hopinterval) and tonumber(server.hopinterval) .. "s" or nil
+			hopInterval = tonumber(server.hopinterval) and tonumber(server.hopinterval) .. "s" or "30s"
 		}
 	},
 --[[			


### PR DESCRIPTION
传输 (Transport)
transport 用于自定义 QUIC 连接使用的底层协议。目前唯一可用的类型是 udp，保留类型选项是为了将来可能添加的其他类型。
```
transport:
  type: udp
  udp:
    hopInterval: 30s 
`````